### PR TITLE
Replace `os.system` with `subprocess`.

### DIFF
--- a/speech/tests/fr_FR/sound.py
+++ b/speech/tests/fr_FR/sound.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import tempfile
 from hashlib import md5
 from os.path import dirname, join
@@ -33,7 +34,7 @@ def create_sound(text, file_name):
         join(os.getenv('HOME'), '.cache', 'gSpeech'),
         1
     )
-    os.system(cmds[0])
+    subprocess.call(cmds[0])
 
 
 def md5_sum(path, file_name):


### PR DESCRIPTION
Avoid calling `/bin/sh` to execute the command.