### PR TITLE
bugfix dockerfiles: add missing `apt-get update` command after having added the ppa repository

### DIFF
--- a/docker/ubuntu-18.04/Dockerfile
+++ b/docker/ubuntu-18.04/Dockerfile
@@ -3,6 +3,7 @@ RUN apt-get update
 
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:jerem-ferry/tts
+RUN apt-get update
 
 RUN apt-get -y install gspeech
 

--- a/docker/ubuntu-20.04/Dockerfile
+++ b/docker/ubuntu-20.04/Dockerfile
@@ -3,6 +3,7 @@ RUN apt-get update
 
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:jerem-ferry/tts
+RUN apt-get update
 
 RUN apt-get -y install gspeech
 


### PR DESCRIPTION
Otherwise, the following install command fails as it doesn't find gspeech in the repositories